### PR TITLE
Balance braces on the GetElementsByFilter example

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -74,7 +74,7 @@
   <script>
     var globalViewer = '';
     var queryResponse = '';
-    let defaultQuery = `query GetElementsByFilter{
+    let defaultQuery = `query GetElementsByFilter {
       elementsByElementGroup(elementGroupId: "yourdesignid", filter: {query:"yourfilter"}) {
         pagination {
             cursor
@@ -88,8 +88,9 @@
                     value
                 }
             }
-        }
-    }`;
+      }
+   }
+}`;
     setInitialTabs();
 
     function setInitialTabs() {


### PR DESCRIPTION
Ran into this error when trying the example and noticed the braces weren't balanced.

```
{
  "errors": [
    {
      "message": "parsing error: syntax error: expected R_CURLY, got EOF",
      "locations": [
        {
          "line": 16,
          "column": 6
        }
      ],
      "extensions": {
        "code": "PARSING_ERROR"
      }
    }
  ]
}
```